### PR TITLE
Updated directory path for downloading ISO image

### DIFF
--- a/boot/gentoo.ipxe
+++ b/boot/gentoo.ipxe
@@ -9,7 +9,7 @@ iseq ${arch} x86_64 && set gt_arch amd64 || set gt_arch x86
 
 echo For Gentoo you need ISO image version number.
 echo See this link for latest build version:
-echo http://distfiles.gentoo.org/releases/${gt_arch}/autobuilds/current-iso/default/
+echo http://distfiles.gentoo.org/releases/${gt_arch}/autobuilds/current-iso/
 echo Example: ${default_version}
 
 echo -n Enter version: ${} && read version
@@ -17,7 +17,7 @@ echo -n Enter version: ${} && read version
 isset ${version} || set version ${default_version}
 
 set mirror http://mirror.rackspace.com/gentoo/
-set dir releases/${gt_arch}/autobuilds/current-iso/default/${version}/
+set dir releases/${gt_arch}/autobuilds/current-iso/
 set iso install-${gt_arch}-minimal-${version}.iso
 
 initrd ${mirror}${dir}${iso}


### PR DESCRIPTION
Old path was releases/${gt_arch}/autobuilds/current-iso/default/${version}/ and it doesn't exist at all (caused also the boot to fail). Correct path is releases/${gt_arch}/autobuilds/current-iso/.
