### PR TITLE
Update centos.ipxe

### DIFF
--- a/boot/centos.ipxe
+++ b/boot/centos.ipxe
@@ -49,7 +49,9 @@ goto bootos_images
 
 :kickstart_device
 echo -n Specify ksdevice param for ${os} ${osversion}: && read ksdevice
-set ksdevice ${ksdevice} ||
+echo -n Specify kickstart URL for ${os} ${osversion}: && read ksurl
+set params ks=${ksurl} ||
+set params ksdevice=${ksdevice} ||
 clear bt
 goto boottype
 


### PR DESCRIPTION
Do we need to specify both the KS url and the KSDEVICE params? Not sure if this is even the issue, but it seemed like being able to specify both would be nice. 
