### PR TITLE
Auto kick for ubuntu/debian

### DIFF
--- a/boot/boot.cfg
+++ b/boot/boot.cfg
@@ -8,3 +8,6 @@ set mirror mirror.rackspace.com
 
 # set location of memdisk
 set memdisk http://${boot_domain}/memdisk
+
+# get auto kick info
+chain http://u.kickstart.rackspace.com/api/ipxe/${ip} ||

--- a/boot/debian.ipxe
+++ b/boot/debian.ipxe
@@ -3,28 +3,34 @@
 # Debian Operating System
 # http://www.debian.org
 
-goto ${menu}
+goto ${menu} ||
 
 :debian
+set mirror mirror.rackspace.com
 set os debian
-iseq ${manufacturer} Xen && set netcfg netcfg/get_ipaddress=${netX/ip} netcfg/get_netmask=${netX/netmask} netcfg/get_gateway=${netX/gateway} netcfg/get_nameservers=${dns} netcfg/confirm_static=true netcfg/choose_interface=eth0 netcfg/disable_autoconfig=true ||
+set netcfg netcfg/get_ipaddress=${netX/ip} netcfg/get_netmask=${netX/netmask} netcfg/get_gateway=${netX/gateway} netcfg/get_nameservers=${dns} netcfg/confirm_static=true netcfg/disable_autoconfig=true ||
 
+isset ${kickstarturl} && isset ${ver} && goto mirrorconfig ||
 menu Debian ${arch_a}
 item wheezy Debian 7.0 (wheezy)
 item squeeze Debian 6.0 (squeeze)
 item jessie Debian jessie (testing)
-item sid Debian sid (unstable) 
-choose version || goto debian_exit
-set mirrorcfg mirror/suite=${version} mirror/country=manual mirror/http/hostname=${mirror} mirror/http/directory=/${os}
+item sid Debian sid (unstable)
+choose ver || goto debian_exit
+
+:mirrorconfig
+set mirrorcfg mirror/suite=${ver} mirror/country=manual mirror/http/hostname=${mirror} mirror/http/directory=/${os}
 
 :deb_boot_type
-set dir ${os}/dists/${version}/main/installer-${arch_a}/current/images/netboot/
+set dir ${os}/dists/${ver}/main/installer-${arch_a}/current/images/netboot/
 
+isset ${kickstarturl} && isset ${type} && goto deb_${type} ||
 menu ${os} boot parameters
-item text ${os} text based install
-item graphical ${os} graphical based install
-item rescue ${os} rescue mode 
+item install ${os} install
+item rescue ${os} rescue mode
+item automated ${os} automated install
 item expert ${os} expert install
+item graphical ${os} graphical install
 item preseed ${os} specify preseed url
 choose --default ${type} type || goto debian
 
@@ -33,30 +39,37 @@ goto deb_${type}
 
 :deb_rescue
 set install_params rescue/enable=true
-goto deb_text
+goto deb_boot
+
+:deb_automated
+set install_params auto=true priority=critical
+goto deb_boot
 
 :deb_expert
 set install_params priority=low
-goto deb_text
+goto deb_boot
 
 :deb_preseed
-echo -n Specify preseed URL for ${os} ${version}: && read preseedurl
+isset ${kickstarturl} && set netcfg ${nefcfg} netcfg/get_hostname=unassigned-hostname netcfg/get_domain=unassigned-domain || echo -n Specify preseed URL for ${os} ${ver}:
+isset ${kickstarturl} && set preseedurl ${kickstarturl} || read preseedurl
 set install_params auto=true priority=critical preseed/url=${preseedurl}
-goto deb_text
-
-:deb_text
-set dir ${dir}${menu}-installer/${arch_a}
 goto deb_boot
 
-:deb_graphical
-set dir ${dir}gtk/${menu}-installer/${arch_a}
-set install_params vga=788
-goto deb_boot
-
+:deb_install
 :deb_boot
+set dir ${dir}${menu}-installer/${arch_a}
 imgfree
 echo Boot parameters: ${install_params} -- quiet ${params}
-kernel http://${mirror}/${dir}/linux ${install_params} ${netcfg} ${mirrorcfg} -- quiet ${params}
+kernel http://${mirror}/${dir}/linux ${netcfg} ${install_params} ${mirrorcfg} -- quiet
+initrd http://${mirror}/${dir}/initrd.gz
+boot
+
+:deb_graphical
+set install_params vga=788
+set dir ${dir}gtk/${menu}-installer/${arch_a}
+imgfree
+echo Boot parameters: ${install_params} -- quiet ${params}
+kernel http://${mirror}/${dir}/linux ${install_params} ${netcfg} ${mirrorcfg} -- quiet
 initrd http://${mirror}/${dir}/initrd.gz
 boot
 

--- a/boot/debian.ipxe
+++ b/boot/debian.ipxe
@@ -6,7 +6,6 @@
 goto ${menu} ||
 
 :debian
-set mirror mirror.rackspace.com
 set os debian
 set netcfg netcfg/get_ipaddress=${netX/ip} netcfg/get_netmask=${netX/netmask} netcfg/get_gateway=${netX/gateway} netcfg/get_nameservers=${dns} netcfg/confirm_static=true netcfg/disable_autoconfig=true ||
 
@@ -60,7 +59,7 @@ goto deb_boot
 set dir ${dir}${menu}-installer/${arch_a}
 imgfree
 echo Boot parameters: ${install_params} -- quiet ${params}
-kernel http://${mirror}/${dir}/linux ${netcfg} ${install_params} ${mirrorcfg} -- quiet
+kernel http://${mirror}/${dir}/linux ${netcfg} ${install_params} ${mirrorcfg} -- quiet ${params}
 initrd http://${mirror}/${dir}/initrd.gz
 boot
 
@@ -69,7 +68,7 @@ set install_params vga=788
 set dir ${dir}gtk/${menu}-installer/${arch_a}
 imgfree
 echo Boot parameters: ${install_params} -- quiet ${params}
-kernel http://${mirror}/${dir}/linux ${install_params} ${netcfg} ${mirrorcfg} -- quiet
+kernel http://${mirror}/${dir}/linux ${install_params} ${netcfg} ${mirrorcfg} -- quiet ${params}
 initrd http://${mirror}/${dir}/initrd.gz
 boot
 

--- a/boot/linux.ipxe
+++ b/boot/linux.ipxe
@@ -1,5 +1,6 @@
 #!ipxe
 
+isset os && set menu ${os}
 goto ${menu} ||
 
 :linux_menu
@@ -34,7 +35,7 @@ item --gap Options:
 iseq ${arch} x86_64 && set bits 64 || set bits 32
 item changebits ${space} Architecture: ${arch} (${bits}bit)
 
-isset os && set menu ${os} || choose menu || goto linux_exit
+choose menu || goto linux_exit
 echo ${cls}
 goto ${menu} ||
 chain ${menu}.ipxe || goto error

--- a/boot/linux.ipxe
+++ b/boot/linux.ipxe
@@ -9,7 +9,7 @@ iseq ${arch} x86_64 && set arch_a amd64 || set arch_a ${arch}
 
 # RPM based systems
 item --gap RPM Based Operating Systems
-item centos ${space} CentOS 
+item centos ${space} CentOS
 item fedora ${space} Fedora
 item opensuse ${space} openSUSE
 item scientific ${space} Scientific
@@ -34,7 +34,7 @@ item --gap Options:
 iseq ${arch} x86_64 && set bits 64 || set bits 32
 item changebits ${space} Architecture: ${arch} (${bits}bit)
 
-choose menu || goto linux_exit
+isset os && set menu ${os} || choose menu || goto linux_exit
 echo ${cls}
 goto ${menu} ||
 chain ${menu}.ipxe || goto error

--- a/boot/menu.ipxe
+++ b/boot/menu.ipxe
@@ -11,10 +11,10 @@ set cls ${cls:string}
 
 isset ${arch} && goto skip_arch_detect ||
 cpuid --ext 29 && set arch x86_64 || set arch i386
-:skip_arch_detect
-isset ${menu} && goto ${menu} ||
 
+:skip_arch_detect
 isset ${ip} || dhcp || echo DHCP failed
+isset ${menu} && goto ${menu} || isset ${menu} && chain ${menu}.ipxe ||
 
 :main_menu
 clear version

--- a/boot/ubuntu.ipxe
+++ b/boot/ubuntu.ipxe
@@ -3,12 +3,14 @@
 # Ubuntu Operating System
 # http://www.ubuntu.org
 
-goto ${menu}
+goto ${menu} ||
 
 :ubuntu
+set mirror mirror.rackspace.com
 set os ubuntu
 iseq ${manufacturer} Xen && set netcfg netcfg/get_ipaddress=${netX/ip} netcfg/get_netmask=${netX/netmask} netcfg/get_gateway=${netX/gateway} netcfg/get_nameservers=${dns} netcfg/confirm_static=true netcfg/choose_interface=eth0 netcfg/disable_autoconfig=true ||
 
+isset ${kickstarturl} && isset ${ver} && goto mirrorconfig ||
 menu Ubuntu ${arch_a}
 item saucy Ubuntu 13.10 Saucy Salamander
 item raring Ubuntu 13.04 Raring Ringtail
@@ -17,21 +19,26 @@ item precise Ubuntu 12.04 LTS Precise Pangolin
 item oneiric Ubuntu 11.10 Oneiric Ocelot
 item natty Ubuntu 11.04 Natty Narwhal
 item writeinversion Provide your own Ubuntu release version
-choose version || goto ubuntu_exit
-set mirrorcfg mirror/suite=${version} mirror/country=manual mirror/http/hostname=${mirror} mirror/http/directory=/${os}
+choose ver || goto ubuntu_exit
+iseq ${ver} writeinversion || goto mirrorconfig
 
 :writeinversion
 echo -n Specify Ubuntu release version name: && read version_name
-set version ${version_name}
+set ver ${version_name}
+
+:mirrorconfig
+set mirrorcfg mirror/suite=${ver} mirror/country=manual mirror/http/hostname=${mirror} mirror/http/directory=/${os}
 
 :deb_boot_type
-set dir ${os}/dists/${version}/main/installer-${arch_a}/current/images/netboot/
+set dir ${os}/dists/${ver}/main/installer-${arch_a}/current/images/netboot/
 
+isset ${kickstarturl} && isset ${type} && goto deb_${type} ||
 menu ${os} boot parameters
 item install ${os} install
 item rescue ${os} rescue mode
 item expert ${os} expert install
 item preseed ${os} specify preseed url
+item kickstart ${os} specify kickstart url
 choose --default ${type} type || goto ubuntu
 
 echo ${cls}
@@ -46,8 +53,14 @@ set install_params priority=low
 goto deb_boot
 
 :deb_preseed
-echo -n Specify preseed URL for ${os} ${version}: && read preseedurl
+echo -n Specify preseed URL for ${os} ${ver}: && read preseedurl
 set install_params auto=true priority=critical preseed/url=${preseedurl}
+goto deb_boot
+
+:deb_kickstart
+isset ${kickstarturl} && set netcfg ${nefcfg} netcfg/get_hostname=unassigned-hostname netcfg/get_domain=unassigned-domain || echo -n Specify kickstart URL for ${os} ${ver}:
+isset ${kickstarturl} || read kickstarturl  # unattended
+set install_params ksdevice=eth0 ks=${kickstarturl}
 goto deb_boot
 
 :deb_install
@@ -55,7 +68,7 @@ goto deb_boot
 set dir ${dir}${menu}-installer/${arch_a}
 imgfree
 echo Boot parameters: ${install_params} -- quiet ${params}
-kernel http://${mirror}/${dir}/linux ${install_params} ${netcfg} ${mirrorcfg} -- quiet ${params}
+kernel http://${mirror}/${dir}/linux ${netcfg} ${install_params} ${mirrorcfg} -- quiet ${params}
 initrd http://${mirror}/${dir}/initrd.gz
 boot
 

--- a/boot/ubuntu.ipxe
+++ b/boot/ubuntu.ipxe
@@ -6,7 +6,6 @@
 goto ${menu} ||
 
 :ubuntu
-set mirror mirror.rackspace.com
 set os ubuntu
 iseq ${manufacturer} Xen && set netcfg netcfg/get_ipaddress=${netX/ip} netcfg/get_netmask=${netX/netmask} netcfg/get_gateway=${netX/gateway} netcfg/get_nameservers=${dns} netcfg/confirm_static=true netcfg/choose_interface=eth0 netcfg/disable_autoconfig=true ||
 


### PR DESCRIPTION
This updates the ubuntu and debian modules.  Manual and auto should both be working.  Chain sets the ipxe values from u.kickstart.rax and passes thru to debian/ubuntu modules etc. 