### PR TITLE
Adding Fedora 23 Alpha

### DIFF
--- a/boot/fedora.ipxe
+++ b/boot/fedora.ipxe
@@ -12,10 +12,11 @@ clear ova
 set os Fedora
 menu Fedora ${arch}
 iseq ${manufacturer} Xen && set netcfg ip=${netX/ip} netmask=${netX/netmask} gateway=${netX/gateway} dns=${dns} ksdevice=eth0 ||
+item 23 ${os} 23 Alpha (Development/Test)
 item 22 ${os} 22
 item 21 ${os} 21
 item 20 ${os} 20
-isset ${osversion} || choose osversion || goto linux_menu
+isset ${osversion} || choose --default 22 osversion || goto linux_menu
 set ova ${os} ${osversion}
 iseq ${osversion} 20 && goto legacy_sku ||
 iseq ${osversion} 19 && goto legacy_sku ||
@@ -29,6 +30,7 @@ item Server ${ova} Server
 item Workstation ${ova} Workstation
 isset ${sku_type} || choose sku_type || goto fedora
 set dir fedora/releases/${osversion}/${sku_type}/${arch}/os
+iseq ${osversion} 23 && set dir fedora/releases/test/23_Alpha/${sku_type}/${arch}/os
 set ova ${ova} ${sku_type}
 echo ${cls}
 goto boottype


### PR DESCRIPTION
This commit adds Fedora 23 Alpha to the menu but leaves Fedora 22 as the default selection.